### PR TITLE
Fix undercounting of solo and intact elements

### DIFF
--- a/bin/solo_intact_ratio.pl
+++ b/bin/solo_intact_ratio.pl
@@ -24,7 +24,7 @@ while (<Intact>){
 	if (exists $all{$id}){
 		$all{$id}[1]++; #count intact number
 		} else {
-		$all{$id}=["0", "0"]; #initialize count of solo and intact number
+		$all{$id}=["0", "1"]; #initialize count of solo and intact number
 		}
 	}
 close Intact;
@@ -36,7 +36,7 @@ while (<Solo>){
 	if (exists $all{$id}){
 		$all{$id}[0]++; #count solo number
 		} else {
-		$all{$id}=["0", "0"];
+		$all{$id}=["1", "0"];
 		}
 	}
 close Solo;


### PR DESCRIPTION
Upon first encountering an ID, the counts for solo and intact are both initialized to zero, failing to count the first occurrence of a solo or intact element for each ID.